### PR TITLE
Sort Patients By Priority

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -66,7 +66,7 @@ dependencies {
 }
 
 shadowJar {
-    archiveFileName = 'addressbook.jar'
+    archiveFileName = 'NovaCareApp.jar'
 }
 
 defaultTasks 'clean', 'test'

--- a/src/main/java/seedu/address/logic/commands/SortByPriorityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortByPriorityCommand.java
@@ -10,14 +10,14 @@ import seedu.address.model.Model;
  */
 public class SortByPriorityCommand extends Command {
 
-        public static final String COMMAND_WORD = "sortbypriority";
+    public static final String COMMAND_WORD = "sortbypriority";
 
-        public static final String MESSAGE_SUCCESS = "Sorted all tasks by priority level";
+    public static final String MESSAGE_SUCCESS = "Sorted all tasks by priority level";
 
-        @Override
-        public CommandResult execute(Model model) {
-            requireNonNull(model);
-            model.sortPatientsByPriority(PREDICATE_SHOW_ALL_PERSONS);
-            return new CommandResult(MESSAGE_SUCCESS);
-        }
+    @Override
+    public CommandResult execute(Model model) {
+        requireNonNull(model);
+        model.sortPatientsByPriority(PREDICATE_SHOW_ALL_PERSONS);
+        return new CommandResult(MESSAGE_SUCCESS);
+    }
 }

--- a/src/main/java/seedu/address/logic/commands/SortByPriorityCommand.java
+++ b/src/main/java/seedu/address/logic/commands/SortByPriorityCommand.java
@@ -1,0 +1,23 @@
+package seedu.address.logic.commands;
+
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+
+import seedu.address.model.Model;
+
+/**
+ * Sorts all tasks by priority level from most important to least important.
+ */
+public class SortByPriorityCommand extends Command {
+
+        public static final String COMMAND_WORD = "sortbypriority";
+
+        public static final String MESSAGE_SUCCESS = "Sorted all tasks by priority level";
+
+        @Override
+        public CommandResult execute(Model model) {
+            requireNonNull(model);
+            model.sortPatientsByPriority(PREDICATE_SHOW_ALL_PERSONS);
+            return new CommandResult(MESSAGE_SUCCESS);
+        }
+}

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -24,6 +24,7 @@ import seedu.address.logic.commands.HelpCommand;
 import seedu.address.logic.commands.ListCommand;
 import seedu.address.logic.commands.MarkTaskCommand;
 import seedu.address.logic.commands.PriorityCommand;
+import seedu.address.logic.commands.SortByPriorityCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 
 /**
@@ -104,6 +105,9 @@ public class AddressBookParser {
 
         case DeletePriorityCommand.COMMAND_WORD:
             return new DeletePriorityCommandParser().parse(arguments);
+
+        case SortByPriorityCommand.COMMAND_WORD:
+            return new SortByPriorityCommand();
 
         default:
             logger.finer("This user input caused a ParseException: " + userInput);

--- a/src/main/java/seedu/address/model/AddressBook.java
+++ b/src/main/java/seedu/address/model/AddressBook.java
@@ -144,6 +144,12 @@ public class AddressBook implements ReadOnlyAddressBook {
         persons.remove(key);
     }
 
+    /**
+     *
+     */
+    public void sortPersonsByPriority() {
+        persons.sortByPriority();
+    }
     //// util methods
 
     @Override

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -124,4 +124,9 @@ public interface Model {
      * @param target The person whose priority level is to be reset.
      */
     void resetPersonPriority(Person target);
+
+    /**
+     * Sort patients by priority level from level 1 to 3. (Most to least important)
+     */
+    void sortPatientsByPriority(Predicate<Person> predicate);
 }

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -5,7 +5,6 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
-import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -5,6 +5,7 @@ import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.function.Predicate;
 import java.util.logging.Logger;
@@ -207,4 +208,9 @@ public class ModelManager implements Model {
         setPerson(target, resetPerson);
     }
 
+    @Override
+    public void sortPatientsByPriority(Predicate<Person> predicate) {
+        addressBook.sortPersonsByPriority();
+        updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+    }
 }

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -3,6 +3,7 @@ package seedu.address.model.person;
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.util.CollectionUtil.requireAllNonNull;
 
+import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 
@@ -98,11 +99,25 @@ public class UniquePersonList implements Iterable<Person> {
     }
 
     /**
+     * Sorts the list by priority level 1 to 3 (most to least important).
+     */
+    public void sortByPriority() {
+        FXCollections.sort(internalList, Comparator.comparingInt(person -> person.getPriorityLevel().getValue()));
+    }
+
+    /**
      * Returns the backing list as an unmodifiable {@code ObservableList}.
      */
     public ObservableList<Person> asUnmodifiableObservableList() {
         return internalUnmodifiableList;
     }
+
+//    /**
+//     * Returns the priority list as an unmodifiable {@code ObservableList}.
+//     */
+//    public ObservableList<Person> asUnmodifiablePriorityList() {
+//        return internalUnmodifiablePriorityList;
+//    }
 
     @Override
     public Iterator<Person> iterator() {

--- a/src/main/java/seedu/address/model/person/UniquePersonList.java
+++ b/src/main/java/seedu/address/model/person/UniquePersonList.java
@@ -112,13 +112,6 @@ public class UniquePersonList implements Iterable<Person> {
         return internalUnmodifiableList;
     }
 
-//    /**
-//     * Returns the priority list as an unmodifiable {@code ObservableList}.
-//     */
-//    public ObservableList<Person> asUnmodifiablePriorityList() {
-//        return internalUnmodifiablePriorityList;
-//    }
-
     @Override
     public Iterator<Person> iterator() {
         return internalList.iterator();

--- a/src/main/java/seedu/address/ui/HelpWindow.java
+++ b/src/main/java/seedu/address/ui/HelpWindow.java
@@ -7,7 +7,6 @@ import java.net.URISyntaxException;
 import java.util.logging.Logger;
 
 import javafx.fxml.FXML;
-import javafx.scene.control.Button;
 import javafx.scene.control.Hyperlink;
 import javafx.scene.control.Label;
 import javafx.scene.input.Clipboard;
@@ -22,12 +21,9 @@ public class HelpWindow extends UiPart<Stage> {
 
     public static final String USERGUIDE_URL = "https://ay2425s1-cs2103t-f15-1.github.io/tp/UserGuide.html";
     public static final String HELP_MESSAGE = "Refer to the user guide:";
-    private static final String HELP_COMMAND = getAllCommands();
+    private static final String HELP_COMMAND = getPatientCommands() + getTaskCommands() + otherCommands();
     private static final Logger logger = LogsCenter.getLogger(HelpWindow.class);
     private static final String FXML = "HelpWindow.fxml";
-
-    @FXML
-    private Button copyButton;
 
     @FXML
     private Label helpMessage;
@@ -115,21 +111,53 @@ public class HelpWindow extends UiPart<Stage> {
     }
 
     /**
-     * Returns the list of all commands.
+     * Returns the list of patient commands.
      */
-    public static String getAllCommands() {
-        return "Here are the list of commands available:\n"
-                + "1. add\n"
-                + "2. delete\n"
-                + "3. addtask\n"
-                + "4. deletetask\n"
-                + "5. emergency\n"
-                + "6. priority\n"
-                + "7. list\n"
-                + "8. help\n"
-                + "9. exit\n"
-                + "10. find\n"
-                + "11. clear\n";
+    public static String getPatientCommands() {
+        return """
+                For more information on the commands, please refer to the user guide.
+                Alternatively, you can the type commands to view more details and example.
+
+                Here are the list of Patient Commands available:
+                1. add (add patient)
+                2. delete (delete patient)
+                3. emergency (set emergency contact)\s
+                4. delemergency (delete emergency contact)
+                5. priority (set or edit priority level)
+                6. deletelevel (delete priority level)
+                7. find (find a person)
+                8. list (list all persons)
+                9. clear (clear all persons)
+                10. sortbypriority (sort Patients by priority level 1 to 3)
+                """;
+    }
+
+    /**
+     * Returns the list of task commands.
+     */
+    public static String getTaskCommands() {
+        return """
+
+                 Here are the list of Patient Commands available:
+                1. addtask (add a task)
+                2. deletetask (delete task)
+                3. findtask (find a task)
+                4. listtask (list all tasks)
+                5. listincomplete (list incomplete tasks)
+                6. marktask (mark a task as complete)
+                """;
+    }
+
+    /**
+     * Returns the list of other commands.
+     */
+    public static String otherCommands() {
+        return """
+
+                 Here are the list of Other Commands available:
+                1. help (show help page)
+                2. exit (exit the application)
+                """;
     }
 
     /**

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -169,6 +169,15 @@ public class MainWindow extends UiPart<Stage> {
         primaryStage.hide();
     }
 
+    /**
+     * Executes the command and returns the result.
+     */
+    private void updatePersonListPanel() {
+        personListPanel = new PersonListPanel(logic.getFilteredPersonList());
+        personListPanelPlaceholder.getChildren().clear(); // Clear existing children
+        personListPanelPlaceholder.getChildren().add(personListPanel.getRoot()); // Add the new panel
+    }
+
     public PersonListPanel getPersonListPanel() {
         return personListPanel;
     }
@@ -191,6 +200,10 @@ public class MainWindow extends UiPart<Stage> {
             if (commandResult.isExit()) {
                 handleExit();
             }
+
+//            if(commandResult.isSort()) {
+//                updatePersonListPanel();
+//            }
 
             return commandResult;
         } catch (CommandException | ParseException e) {

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -201,10 +201,6 @@ public class MainWindow extends UiPart<Stage> {
                 handleExit();
             }
 
-//            if(commandResult.isSort()) {
-//                updatePersonListPanel();
-//            }
-
             return commandResult;
         } catch (CommandException | ParseException e) {
             logger.info("An error occurred while executing command: " + commandText);

--- a/src/main/resources/view/HelpWindow.fxml
+++ b/src/main/resources/view/HelpWindow.fxml
@@ -3,7 +3,6 @@
 <?import java.net.URL?>
 <?import javafx.geometry.Insets?>
 <?import javafx.scene.Scene?>
-<?import javafx.scene.control.Button?>
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.image.Image?>
 <?import javafx.scene.layout.HBox?>
@@ -27,11 +26,6 @@
             <Label fx:id="helpMessage" text="Label"/>
             <Hyperlink fx:id="userGuideLink"
                        text="https://ay2425s1-cs2103t-f15-1.github.io/tp/UserGuide.html(Click me)" />
-            <Button fx:id="copyButton" mnemonicParsing="false" onAction="#copyUrl" text="Copy URL">
-              <HBox.margin>
-                <Insets left="5.0" />
-              </HBox.margin>
-            </Button>
           </children>
         </HBox>
         <VBox fx:id="helpCommandsContainer">

--- a/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
+++ b/src/test/data/JsonSerializableAddressBookTest/typicalPersonsAddressBook.json
@@ -5,8 +5,8 @@
     "phone" : "94351253",
     "email" : "alice@example.com",
     "address" : "123, Jurong West Ave 6, #08-111",
-    "emergency contact name" : "",
-    "emergency contact number" : "",
+    "emergency contact name" : "Billy",
+    "emergency contact number" : "77777777",
     "tags" : [ "friends" ],
     "priorityLevel": 3
   }, {
@@ -14,8 +14,8 @@
     "phone" : "98765432",
     "email" : "johnd@example.com",
     "address" : "311, Clementi Ave 2, #02-25",
-    "emergency contact name" : "",
-    "emergency contact number" : "",
+    "emergency contact name" : "Ken",
+    "emergency contact number" : "66666666",
     "tags" : [ "owesMoney", "friends" ],
     "priorityLevel": 3
   }, {
@@ -44,7 +44,7 @@
     "emergency contact name" : "",
     "emergency contact number" : "",
     "tags" : [ ],
-    "priorityLevel": 3
+    "priorityLevel": 1
   }, {
     "name" : "Fiona Kunz",
     "phone" : "9482427",
@@ -62,6 +62,6 @@
     "emergency contact name" : "",
     "emergency contact number" : "",
     "tags" : [ ],
-    "priorityLevel": 3
-  } ]
+    "priorityLevel": 2
+  }]
 }

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -208,6 +208,11 @@ public class AddCommandTest {
             priorityWasReset = true;
         }
 
+        @Override
+        public void sortPatientsByPriority(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
+
         public boolean wasPriorityReset() {
             return priorityWasReset;
         }

--- a/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddTaskCommandTest.java
@@ -263,6 +263,11 @@ public class AddTaskCommandTest {
         public void resetPersonPriority(Person target) {
             // No operation needed for this stub; this line is necessary to satisfy the interface.
         }
+
+        @Override
+        public void sortPatientsByPriority(Predicate<Person> predicate) {
+            throw new AssertionError("This method should not be called.");
+        }
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/SortByPriorityTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortByPriorityTest.java
@@ -1,9 +1,9 @@
 package seedu.address.logic.commands;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/src/test/java/seedu/address/logic/commands/SortByPriorityTest.java
+++ b/src/test/java/seedu/address/logic/commands/SortByPriorityTest.java
@@ -1,0 +1,37 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
+import static seedu.address.testutil.TypicalPersons.getTypicalAddressBook;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+public class SortByPriorityTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_sortByPriority_success() {
+        new SortByPriorityCommand().execute(model);
+
+        // Update expected model's internal list to reflect the sorted order
+        expectedModel.sortPatientsByPriority(PREDICATE_SHOW_ALL_PERSONS);
+
+        // Assert command success
+        assertCommandSuccess(new SortByPriorityCommand(), model, SortByPriorityCommand.MESSAGE_SUCCESS, expectedModel);
+        assertEquals(expectedModel.getAddressBook().getPersonList(), model.getAddressBook().getPersonList());
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -21,6 +21,7 @@ import seedu.address.logic.commands.AddTaskCommand;
 import seedu.address.logic.commands.ClearCommand;
 import seedu.address.logic.commands.DeleteCommand;
 import seedu.address.logic.commands.DeleteEmergencyContactCommand;
+import seedu.address.logic.commands.DeletePriorityCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
 import seedu.address.logic.commands.EmergencyContactCommand;
@@ -33,6 +34,7 @@ import seedu.address.logic.commands.ListIncompleteCommand;
 import seedu.address.logic.commands.ListTaskCommand;
 import seedu.address.logic.commands.MarkTaskCommand;
 import seedu.address.logic.commands.PriorityCommand;
+import seedu.address.logic.commands.SortByPriorityCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.person.EmergencyContact;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
@@ -194,4 +196,16 @@ public class AddressBookParserTest {
 
     }
 
+    @Test
+    public void parseCommand_SortByPriority() throws Exception {
+        assertTrue(parser.parseCommand(SortByPriorityCommand.COMMAND_WORD) instanceof SortByPriorityCommand);
+        assertTrue(parser.parseCommand(SortByPriorityCommand.COMMAND_WORD + " 1")
+                instanceof SortByPriorityCommand);
+    }
+
+    @Test
+    public void parseCommand_deletePriority() throws Exception {
+        DeletePriorityCommand command = (DeletePriorityCommand) parser.parseCommand("deletelevel 2");
+        assertEquals(new DeletePriorityCommand(2), command);
+    }
 }

--- a/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/AddressBookParserTest.java
@@ -197,7 +197,7 @@ public class AddressBookParserTest {
     }
 
     @Test
-    public void parseCommand_SortByPriority() throws Exception {
+    public void parseCommand_sortByPriority() throws Exception {
         assertTrue(parser.parseCommand(SortByPriorityCommand.COMMAND_WORD) instanceof SortByPriorityCommand);
         assertTrue(parser.parseCommand(SortByPriorityCommand.COMMAND_WORD + " 1")
                 instanceof SortByPriorityCommand);

--- a/src/test/java/seedu/address/model/ModelManagerTest.java
+++ b/src/test/java/seedu/address/model/ModelManagerTest.java
@@ -7,6 +7,8 @@ import static seedu.address.model.Model.PREDICATE_SHOW_ALL_PERSONS;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalPersons.ALICE;
 import static seedu.address.testutil.TypicalPersons.BENSON;
+import static seedu.address.testutil.TypicalPersons.FIONA;
+import static seedu.address.testutil.TypicalPersons.GEORGE;
 
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -203,5 +205,22 @@ public class ModelManagerTest {
 
         // Verify the priority level remains 3 after multiple resets
         assertEquals(3, ALICE.getPriorityLevel().getValue());
+    }
+
+    @Test
+    public void sortPatientsByPriority_validPredicate_personsSortedByPriority() {
+        AddressBook addressBook = new AddressBookBuilder().withPerson(FIONA).withPerson(GEORGE).build();
+        ModelManager modelManager = new ModelManager(addressBook, new UserPrefs());
+
+        // Ensure the initial order of persons is not sorted by priority
+        assertEquals(FIONA, modelManager.getFilteredPersonList().get(0));
+        assertEquals(GEORGE, modelManager.getFilteredPersonList().get(1));
+
+        // Sort the persons by priority
+        modelManager.sortPatientsByPriority(PREDICATE_SHOW_ALL_PERSONS);
+
+        // Ensure the persons are sorted by priority
+        assertEquals(GEORGE, modelManager.getFilteredPersonList().get(0));
+        assertEquals(FIONA, modelManager.getFilteredPersonList().get(1));
     }
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -49,13 +49,13 @@ public class TypicalPersons {
             .build();
     public static final Person ELLE = new PersonBuilder().withName("Elle Meyer").withPhone("9482224")
             .withEmail("werner@example.com").withAddress("michegan ave")
-            .withEmergencyContact("", "99999999").withPriorityLevel(3)
+            .withEmergencyContact("", "99999999").withPriorityLevel(1)
             .build();
     public static final Person FIONA = new PersonBuilder().withName("Fiona Kunz").withPhone("9482427")
             .withEmail("lydia@example.com").withAddress("little tokyo").withPriorityLevel(3)
             .build();
     public static final Person GEORGE = new PersonBuilder().withName("George Best").withPhone("9482442")
-            .withEmail("anna@example.com").withAddress("4th street").withPriorityLevel(3)
+            .withEmail("anna@example.com").withAddress("4th street").withPriorityLevel(2)
             .build();
 
     // Manually added


### PR DESCRIPTION
Users can use sortbypriority command to sort the patients list from Level 1 to 3.
When the application is closed and reopens, the sorting still persist.